### PR TITLE
Reorder icons

### DIFF
--- a/src/CharacterCard/CharacterCard.js
+++ b/src/CharacterCard/CharacterCard.js
@@ -14,8 +14,6 @@ export default class CharacterCard extends React.Component{
             <div className="draggable" 
                 draggable 
                 onDragStart={(e)=>this.onDragStart(e, this.characterName)}
-                /*onMouseEnter = {(character) => this.props.onMouseEnter(this.characterName)}
-                onMouseLeave = {()=>this.props.onMouseLeave()}*/
                 onDragOver = {(e,character)=>this.props.onDragOver(e,this.characterName)}
                 onDragLeave ={(e)=>this.props.onDragLeave(e)}>
                 <img  className = "characterImg" src={this.characterImg} alt={this.characterName}/>

--- a/src/CharacterCard/CharacterCard.test.js
+++ b/src/CharacterCard/CharacterCard.test.js
@@ -5,13 +5,7 @@ import { fireEvent, render } from "react-testing-library";
 
 describe("Character Card", function(){
     it("renders  without crashing", function(){
-        const div = document.createElement('div');
-        ReactDOM.render(<CharacterCard name= "fox" />, div);
-    });
-    it("moves on drag", function(){
-        const div = document.createElement('div');
         let characterName = "fox";
-        const {getByAltText} = render(<CharacterCard name= {characterName} />);
-        fireEvent.drag(getByAltText(characterName));
-    });//this test needs more work. it doesn't actually move the card or assert anything about it
+        const icon = render(<CharacterCard name = {characterName}/>);
+    });
 });

--- a/src/CharacterSelectionGrid/CharacterSelectionGrid.js
+++ b/src/CharacterSelectionGrid/CharacterSelectionGrid.js
@@ -12,8 +12,6 @@ export default class CharacterSelectionGrid extends React.Component{
             return (
                 <CharacterCard 
                     className = "characterIcon"
-                    /*onMouseEnter = {(character) => this.props.onMouseEnter(character)}
-                    onMouseLeave = {() => this.props.onMouseLeave()}*/
                     onDragOver = {(e,character) => this.props.onDragOver(e,character)}
                     onDragLeave ={(e)=>this.props.onDragLeave(e)}
                     key = {name}

--- a/src/CharacterSelectionGrid/CharacterSelectionGrid.test.js
+++ b/src/CharacterSelectionGrid/CharacterSelectionGrid.test.js
@@ -1,12 +1,20 @@
 import React from "react"
-import ReactDOM from "react-dom"
 import CharacterSelectionGrid from "./CharacterSelectionGrid"
-import { render } from "react-testing-library";
+import { render, getByAltText } from "react-testing-library";
 
 describe("Character Selection Grid" , function(){
     it("renders without crashing", function(){
-        const div = document.createElement("div");
-        let characterName = "fox";
-        ReactDOM.render(<CharacterSelectionGrid characterList = {[characterName]}/>, div);
+        let characterName = ["fox"];
+        const grid = render(<CharacterSelectionGrid characterList = {characterName}/>);
+    });
+    it("renders all character icons", function(){
+        let characterNames = ["fox","yoshi","bowser"];
+        const {getByAltText} = render(<CharacterSelectionGrid characterList = {characterNames}/>);
+        const fox = getByAltText("fox");
+        const yoshi = getByAltText("yoshi");
+        const bowser = getByAltText("bowser");
+        expect(fox).toBeDefined();
+        expect(yoshi).toBeDefined();
+        expect(bowser).toBeDefined();
     });
 });

--- a/src/TierListChart/TierListChart.js
+++ b/src/TierListChart/TierListChart.js
@@ -17,8 +17,6 @@ export default class TierListChart extends React.Component{
             charactersByRow[this.allCharacters[i][1]].push(
                 <CharacterCard 
                     className = "characterIcon" 
-                    /*onMouseEnter = {(character) => this.props.onMouseEnter(character)}
-                    onMouseLeave = {() => this.props.onMouseLeave()}*/
                     onDragOver = {(e,character)=>this.props.onDragOver(e,character)}
                     onDragLeave ={(e)=>this.props.onDragLeave(e)}
                     key = {this.allCharacters[i][0]}
@@ -32,7 +30,7 @@ export default class TierListChart extends React.Component{
     createRows(charactersByRow){
         let rows = [];
         for(let i = 0; i < this.rowCount; i++){
-            rows.push(<div key = {i} className = "tierListRow" onDrop = {(e)=>this.props.onDrop(e,i+1)} onDragOver = {(e)=>this.onDragOver(e)}>{charactersByRow[i]}</div>)
+            rows.push(<div key = {i} className = "tierListRow" placeholder = {"row"+i} onDrop = {(e)=>this.props.onDrop(e,i+1)} onDragOver = {(e)=>this.onDragOver(e)}>{charactersByRow[i]}</div>)
         }
         return rows;
     }

--- a/src/TierListChart/TierListChart.test.js
+++ b/src/TierListChart/TierListChart.test.js
@@ -3,10 +3,9 @@ import ReactDOM from "react-dom"
 import TierListChart from "./TierListChart"
 import { render } from "react-testing-library";
 
-describe("Character Selection Grid" , function(){
+describe("Tier List Grid" , function(){
     it("renders without crashing", function(){
-        const div = document.createElement("div");
         let characterName = "fox";
-        ReactDOM.render(<TierListChart characterList = {[[characterName,1]]}/>, div);
+        render(<TierListChart characterList = {[[characterName,1]]}/>);
     });
 });

--- a/src/WindowGrid/WindowGrid.js
+++ b/src/WindowGrid/WindowGrid.js
@@ -49,14 +49,14 @@ export default class WindowGrid extends React.Component{
         let name = ev.dataTransfer.getData("name");
         this.moveCharacters(name,row);
     }
-    onDragOverIcon(ev, hoveredCharacter){//onDragOver?
+    onDragOverIcon(ev, hoveredCharacter){
         ev.preventDefault();
         console.log('drag over', hoveredCharacter);
         this.setState({
             hoveredCharacter: hoveredCharacter,
         })
     }
-    onDragLeaveIcon(ev){//onDragLeave?
+    onDragLeaveIcon(ev){
         ev.preventDefault();
         console.log('not over character anymore');
         this.setState({
@@ -71,15 +71,11 @@ export default class WindowGrid extends React.Component{
                     <TierListChart 
                         characterList = {this.state.inTierListGrid} 
                         onDrop = {(ev,row) => this.onDrop(ev,row)}
-                        /*onMouseEnter = {(character) => this.onMouseEnter(character)}
-                        onMouseLeave = {() => this.onMouseLeave()}*/
                         onDragOver = {(e,character) =>this.onDragOverIcon(e,character)}
                         onDragLeave = {(e)=>this.onDragLeaveIcon(e)}/>
                     <CharacterSelectionGrid 
                         characterList = {this.state.inSelectionGrid}
                         onDrop = {(ev,row) => this.onDrop(ev,row)}
-                        /*onMouseEnter = {(character) => this.onMouseEnter(character)}
-                        onMouseLeave = {() => this.onMouseLeave()}*/
                         onDragOver = {(e,character) =>this.onDragOverIcon(e,character)}
                         onDragLeave = {(e)=>this.onDragLeaveIcon(e)}/>
                 </div>


### PR DESCRIPTION
**purpose:** the purpose of this work item was to make it possible to reorder icons within a row.
**changes:** added drag over and drag leave actions for each icon. When an icon is dragged over a different icon, the state in window grid is updated with the icon being dragged over. When the icon is dropped, if it is still dragged over an icon, it is added to the row in front of the icon that is being dragged over. 
**testing:** created + refactored some of the unit tests.