### PR TITLE
Prevent drag/drop actions on null elements

### DIFF
--- a/src/WindowGrid/WindowGrid.js
+++ b/src/WindowGrid/WindowGrid.js
@@ -13,6 +13,7 @@ export default class WindowGrid extends React.Component{
         };
     };
     moveCharacters(currentCharacter,currentRow, transparent){
+        if(currentCharacter === null) return;
         let newCharacters = this.state.characters.slice();
         let hoveredCharacter = this.state.hoveredCharacter;
         if(currentCharacter === hoveredCharacter){


### PR DESCRIPTION
**Purpose:** I noticed an issue where if you highlight the row labels and then drag them over the tier list rows, it would cause an issue where it would call "moveCharacters" while the "draggedcharacter" state value was still null. Trying to render a null character icon threw an exception and caused the application to crash.
**Details of Change:** move character should never be called if the "draggedCharacter" state value is null, so I added a check to that method to quit out if something invalid invokes the drag related functions.
**Testing Considerations:** Verified existing tests continued to pass. Will investigate extending test coverage around the window grid functions, but I do not know how to do that with the existing test library that I am using.