### PR TITLE
Moved Character Selection Grid

### DIFF
--- a/react-app/src/WindowGrid/WindowGrid.js
+++ b/react-app/src/WindowGrid/WindowGrid.js
@@ -126,22 +126,24 @@ class WindowGrid extends React.Component{
                     : null
                 }
                 <Toolbar save = {() => this.togglePopup()} search = {() => this.togglePopup()}/>
-                <TierListChart 
-                    characterList = {this.state.characters.filter((icons) => icons.row !== -1)} 
-                    onDragStart = {(name) => this.onDragStart(name)}
-                    onDrop = {() => this.onDrop()}
-                    onDragOverIcon = {(e,character,row) =>this.onDragOverIcon(e,character,row)}
-                    onDragOverRow = {(row) => this.onDragOverRow(row)}
-                    onDragLeaveIcon = {(e)=>this.onDragLeaveIcon(e)}
-                    resetRow = {(row)=>this.resetRow(row)}
-                    deleteRow = {(row)=>this.deleteRow(row)}
-                    insertRow = {(row)=>this.insertRow(row)}/>
-                <CharacterSelectionGrid 
-                    characterList = {this.state.characters.filter((icons) => icons.row === -1)}
-                    onDragStart = {(name) => this.onDragStart(name)}
-                    onDrop = {() => this.onDrop()}
-                    onDragOverIcon = {(e,character,row) =>this.onDragOverIcon(e,character,row)}
-                    onDragLeaveIcon = {(e)=>this.onDragLeaveIcon(e)}/>
+                <div className = "tierListArea">
+                    <TierListChart 
+                        characterList = {this.state.characters.filter((icons) => icons.row !== -1)} 
+                        onDragStart = {(name) => this.onDragStart(name)}
+                        onDrop = {() => this.onDrop()}
+                        onDragOverIcon = {(e,character,row) =>this.onDragOverIcon(e,character,row)}
+                        onDragOverRow = {(row) => this.onDragOverRow(row)}
+                        onDragLeaveIcon = {(e)=>this.onDragLeaveIcon(e)}
+                        resetRow = {(row)=>this.resetRow(row)}
+                        deleteRow = {(row)=>this.deleteRow(row)}
+                        insertRow = {(row)=>this.insertRow(row)}/>
+                    <CharacterSelectionGrid 
+                        characterList = {this.state.characters.filter((icons) => icons.row === -1)}
+                        onDragStart = {(name) => this.onDragStart(name)}
+                        onDrop = {() => this.onDrop()}
+                        onDragOverIcon = {(e,character,row) =>this.onDragOverIcon(e,character,row)}
+                        onDragLeaveIcon = {(e)=>this.onDragLeaveIcon(e)}/>
+                </div>  
             </div>
         );
     }

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -3,7 +3,7 @@ body{
 }
 .characterImg{
   height: 82px;
-  width:82px;
+  width:82px;  
   margin-top: 4px;
 }
 .characterImgTransparent{
@@ -13,23 +13,24 @@ body{
   opacity: .5;
 }
 .characterIcon{
-  height: 33%;
-  width: 11%;
 }
 .characterSelectionGrid{
   display: flex;
-  align-self: center;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: center;
-  padding: 25px;
-  width: 100%;
-  max-width: 750px;
-  min-height: 100px;
+  align-content: flex-start;
+  padding: 20px;
+  width: 35%;  
+  border: 1px solid black;
 }
 .contentBody{
   display:flex;
   flex-direction: column;  
+  background-color: rgb(30, 32, 32);
+}
+.tierListArea{
+  display: flex;
+  flex-direction: row;
   background-color: rgb(30, 32, 32);
 }
 .tierListRow{
@@ -79,6 +80,7 @@ body{
 }
 .tierListChart{
   position: relative;
+  width: 65%;
 }
 .contextMenu{
   background-color: #D3D3D3;
@@ -107,9 +109,9 @@ body{
 }
 .toolbarWrapper{
   display: flex;
-  border: 1px solid black;
   flex-direction:row;
   justify-content:space-between;
+  border-left: 1px solid black;
 }
 .toolbarText{
   background-color:rgb(226, 238, 238);


### PR DESCRIPTION
**Purpose:** The purpose of this work item was to move the character selection grid to the right of the tier list rows, so that on smaller screens, the user will not have to scroll down to grab character icons.
**Details of Changes:**
- changes layout of the tier list grid area to move the character selection grid and tier list rows to be in a row not column.
- misc. styling changes
changed some styling around to move the character selection grid to the right of the tier list rows

**Testing Considerations:** Verified existing tests still pass after the styling changes.